### PR TITLE
Change logo text to hiragana

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -44,9 +44,16 @@ export async function Footer() {
           <div className="grid md:grid-cols-4 gap-8 text-sm">
             <div className="space-y-2">
               <Link href="/">
-                <Image src="/logo.png" alt="RIDE JOB" width={160} height={48} className="h-12 w-auto" />
+                <Image
+                  src="/logo.png"
+                  alt="らいどじょぶ ロゴ"
+                  aria-label="らいどじょぶ ロゴ"
+                  width={160}
+                  height={48}
+                  className="h-12 w-auto"
+                />
               </Link>
-              <p className="text-xs text-blue-600 font-bold">ライドジョブ</p>
+              <p className="text-xs text-blue-600 font-bold">らいどじょぶ</p>
               <p className="text-gray-600 text-sm">
                 ドライバー業界の魅力発信メディア
               </p>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,13 +43,14 @@ export function Header({ categories }: { categories: Category[] }) {
             <div>
               <Image
                 src="/logo.png"
-                alt="RIDE JOB"
+                alt="らいどじょぶ ロゴ"
+                aria-label="らいどじょぶ ロゴ"
                 width={160}
                 height={48}
                 priority
                 className="h-12 w-auto"
               />
-              <p className="text-xs text-blue-600 text-center font-bold">ライドジョブ</p>
+              <p className="text-xs text-blue-600 text-center font-bold">らいどじょぶ</p>
             </div>
           </Link>
 


### PR DESCRIPTION
## Summary
- update header logo alt text and caption from `ライドジョブ` to `らいどじょぶ`
- match footer logo text with the new hiragana form

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bca333c90832a89f945c1147a8761